### PR TITLE
Remove automatic URL updates

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -8,9 +8,7 @@ $fileType = 'exe'
 # https://github.com/OpenVPN/openvpn-build/blob/c92af79befec86f21b257b5defba0becb3d7641f/windows-nsis/openvpn.nsi#L107
 $silentArgs = '/S /SELECT_EASYRSA=1'
 $validExitCodes = @(0)
-$url = 'https://build.openvpn.net/downloads/releases/openvpn-install-2.4.1-I601.exe'
 $checksum = '83ac5500f9fc15c65bf8f2ca90f04c3043b7431fef763408c29746a7385b5a3ea313e11cf4fd274559c8cd9ba811cc6df49d2a84b94330f738fa31724edca4ba'
-$urlSig = 'https://build.openvpn.net/downloads/releases/openvpn-install-2.4.1-I601.exe.asc'
 $checksumSig = '8a250f7d77b96de64aa113bb9468f3d26d41f231ab3cb894bfacb8c809631db4227e8c5662d84512ae4fad2facf57ed8cb3e2ac3e6ed719f4d5b195fe43fa225'
 $certFilename = "$toolsDir\openvpn.cer"
 $pgpKeyFileName = "$toolsDir\samuli_public_key.asc"

--- a/update.ps1
+++ b/update.ps1
@@ -1,13 +1,13 @@
 import-module au
 
 $releases = "https://build.openvpn.net/downloads/releases/"
+$url = 'https://build.openvpn.net/downloads/releases/latest/openvpn-install-latest-stable.exe'
+$urlSig = 'https://build.openvpn.net/downloads/releases/latest/openvpn-install-latest-stable.exe.asc'
 
 function global:au_SearchReplace {
    @{
         ".\tools\chocolateyInstall.ps1" = @{
-            "(^[$]url\s*=\s*)('.*')"         = "`$1'$($Latest.url)'"
             "(^[$]checksum\s*=\s*)('.*')"    = "`$1'$($Latest.checksum)'"
-            "(^[$]urlSig\s*=\s*)('.*')"      = "`$1'$($Latest.urlSig)'"
             "(^[$]checksumSig\s*=\s*)('.*')" = "`$1'$($Latest.checksumSig)'"
         }
     }
@@ -25,12 +25,12 @@ function au_BeforeUpdate {
 
     $filePath = "$toolsPath/openvpnInstall.exe"
     Write-Host "Downloading installer to '$filePath'..."
-    $client.DownloadFile($Latest.url, $filePath)
+    $client.DownloadFile($url, $filePath)
     $Latest.checksum = Get-FileHash $filePath -Algorithm sha512 | % Hash
 
     $filePath = "$toolsPath/openvpnInstall.exe.asc"
     Write-Host "Downloading installer signature to '$filePath'..."
-    $client.DownloadFile($Latest.urlSig, $filePath)
+    $client.DownloadFile($urlSig, $filePath)
     $Latest.checksumSig = Get-FileHash $filePath -Algorithm sha512 | % Hash
 }
 
@@ -40,16 +40,8 @@ function global:au_GetLatest {
     $version = $versionPage.Content -match "(?<=OpenVPN stable version: )[0-9.]+"
     $version = $matches[0]
 
-    $versionInstaller = $versionPage.Content -match "(?<=OpenVPN stable installer version: ).+"
-    $versionInstaller = $matches[0]
-
-    $url = $releases + "openvpn-install-" + $versionInstaller + ".exe"
-    $urlSig = $url + ".asc"
-
     @{
         version = $version
-        url     = $url
-        urlSig  = $urlSig
     }
 }
 


### PR DESCRIPTION
Now that we bundle local version of the files there is no need to
update the URLs for downloading the installer. This improvement is
only possible because OpenVPN has an [unchanging latest release URL](https://build.openvpn.net/downloads/releases/latest/)
that can be used instead of the [explicitly versioned URLs](https://build.openvpn.net/downloads/releases/).

The old way, using the explicitly versioned URLs, is preferable if the
files aren't bundled. That is because if the file the URL points to on
openvpn.net is updated, but the chocolatey package has not yet been
updated, then the checksums will not match and user installs will
fail. The files are now being downloaded from chocolatey.org rather
than openvpn.net so unupdated checksums should not be an issue.

I tried using the unchanging URL before in my other pull request but realised the checksum problem detailed above, that's how I noticed this quickly.